### PR TITLE
Move scoreboard above canvas and darken background

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -40,7 +40,7 @@
         canvas {
             display: block;
             margin: 0; /* Removed auto margins to maximize space */
-            background: url('backs.jpg') center center/cover no-repeat;
+            background: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url('backs.jpg') center center/cover no-repeat;
             border-radius: 5px; /* Reduced border radius */
             box-shadow: 0 0 10px rgba(0, 0, 0, 0.3); /* Reduced shadow */
             touch-action: none !important;
@@ -52,6 +52,8 @@
             -webkit-backface-visibility: hidden;
             backface-visibility: hidden;
             will-change: auto;
+            position: relative;
+            z-index: 1;
         }
 
         /* Tablet-specific styling (768px and below, but larger than 480px) */
@@ -472,6 +474,40 @@
             0% { transform: scale(1); }
             50% { transform: scale(1.05); }
             100% { transform: scale(1); }
+        }
+
+        #starCanvas {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            z-index: 0;
+            pointer-events: none;
+        }
+
+        #scoreBoard {
+            position: absolute;
+            top: 10px;
+            left: 50%;
+            transform: translateX(-50%);
+            display: flex;
+            gap: 20px;
+            font-family: 'Orbitron', sans-serif;
+            font-size: 18px;
+            color: #fff;
+            background: rgba(0, 0, 0, 0.6);
+            padding: 5px 12px;
+            border-radius: 8px;
+            z-index: 1001;
+        }
+
+        @media (max-width: 480px) {
+            #scoreBoard {
+                font-size: 14px;
+                gap: 10px;
+                padding: 4px 8px;
+            }
         }
 
         #gameOverScreen { 
@@ -977,12 +1013,18 @@
         </div>
         
         <!-- Press any key prompt in the center -->
-        <div id="pressAnyKeyPrompt">
-        </div>
-        
+    <div id="pressAnyKeyPrompt">
+    </div>
+
 
     </div>
 
+    <div id="scoreBoard">
+        <span id="scoreDisplay">Score: 0</span>
+        <span id="ballsLeftDisplay">Balls Left: 0</span>
+        <span id="lostBallsDisplay">Lost Balls: 0</span>
+    </div>
+    <canvas id="starCanvas"></canvas>
     <canvas id="gameCanvas"></canvas>
     
     <!-- Control Icons -->
@@ -1121,6 +1163,8 @@
 
 
 
+        const starCanvas = document.getElementById('starCanvas');
+        const starCtx = starCanvas.getContext('2d');
         const canvas = document.getElementById('gameCanvas');
         const ctx = canvas ? canvas.getContext('2d') : null;
         if (!canvas || !ctx) {
@@ -1139,12 +1183,9 @@
         const startButton = document.getElementById('startButton');
 
         // Verify single canvas element
-        const canvases = document.getElementsByTagName('canvas');
-        if (canvases.length > 1) {
-            console.error('Multiple canvas elements detected:', canvases.length);
-            for (let i = 1; i < canvases.length; i++) {
-                canvases[i].remove();
-            }
+        const canvases = document.querySelectorAll('#gameCanvas, #starCanvas');
+        if (canvases.length < 2) {
+            console.warn('Expected two canvas elements for starfield and game');
         }
 
         const gameOverScreen = document.getElementById('gameOverScreen');
@@ -1152,6 +1193,9 @@
         const globalHighScoreList = document.getElementById('globalHighScoreList');
         const restartButton = document.getElementById('restartButton');
         const usernameInput = document.getElementById('usernameInput');
+        const scoreDisplay = document.getElementById('scoreDisplay');
+        const ballsLeftDisplay = document.getElementById('ballsLeftDisplay');
+        const lostBallsDisplay = document.getElementById('lostBallsDisplay');
         
         // Performance detection and optimization
         const isTablet = window.innerWidth >= 481 && window.innerWidth <= 1024;
@@ -1195,6 +1239,8 @@
         let lastTapY = 0;
         let tapActive = false;
         let lastFrameTime = 0;
+        const starCount = 150;
+        let stars = [];
         
         // Win zone drag tracking
         let draggedZone = null;
@@ -2199,6 +2245,40 @@
             }
         }
 
+        function initStars() {
+            stars = [];
+            for (let i = 0; i < starCount; i++) {
+                stars.push({
+                    x: Math.random() * starCanvas.width,
+                    y: Math.random() * starCanvas.height,
+                    size: Math.random() * 2 + 1,
+                    vx: (Math.random() - 0.5) * 0.2,
+                    vy: (Math.random() - 0.5) * 0.2
+                });
+            }
+        }
+
+        function drawStars() {
+            starCtx.clearRect(0, 0, starCanvas.width, starCanvas.height);
+            starCtx.fillStyle = '#ffffff';
+            stars.forEach(star => {
+                star.x += star.vx;
+                star.y += star.vy;
+                if (star.x < 0) star.x = starCanvas.width;
+                if (star.x > starCanvas.width) star.x = 0;
+                if (star.y < 0) star.y = starCanvas.height;
+                if (star.y > starCanvas.height) star.y = 0;
+                starCtx.beginPath();
+                starCtx.arc(star.x, star.y, star.size, 0, Math.PI * 2);
+                starCtx.fill();
+            });
+        }
+
+        function starLoop() {
+            drawStars();
+            requestAnimationFrame(starLoop);
+        }
+
         // Responsive canvas size
         function resizeCanvas() {
             try {
@@ -2233,12 +2313,19 @@
                 canvas.height = height;
                 canvas.style.width = `${width}px`;
                 canvas.style.height = `${height}px`;
+                starCanvas.width = width;
+                starCanvas.height = height;
+                starCanvas.style.width = `${width}px`;
+                starCanvas.style.height = `${height}px`;
+                initStars();
                 console.log('Canvas resized:', width, height, 'Mobile:', isMobile);
             } catch (error) {
                 console.error('Resize canvas error:', error);
             }
         }
         resizeCanvas();
+        initStars();
+        starLoop();
         window.addEventListener('resize', resizeCanvas);
 
         // Game objects (declared earlier to avoid initialization errors)
@@ -4179,14 +4266,9 @@
                 });
 
                 // Regular score display
-                ctx.font = `${16 * (canvas.width / 800)}px 'Orbitron', sans-serif`;
-                ctx.fillStyle = 'rgba(255, 255, 255, 0.7)';
-                ctx.shadowColor = 'black';
-                ctx.shadowBlur = 4;
-                ctx.textAlign = 'center';
-                ctx.fillText(`Score: ${score}`, canvas.width / 2, 40 * (canvas.height / 600));
-                ctx.fillText(`Balls Left: ${coinCount}`, canvas.width / 2, 55 * (canvas.height / 600));
-                ctx.fillText(`Lost Balls: ${lostBalls}`, canvas.width / 2, 70 * (canvas.height / 600));
+                scoreDisplay.textContent = `Score: ${score}`;
+                ballsLeftDisplay.textContent = `Balls Left: ${coinCount}`;
+                lostBallsDisplay.textContent = `Lost Balls: ${lostBalls}`;
                 if (bonusFlashTime > 0) {
                     ctx.font = `${24 * (canvas.width / 800)}px 'Orbitron', sans-serif`;
                     ctx.fillStyle = `rgba(255, 255, 0, ${Math.max(0.4, bonusFlashTime / 60)})`; // Minimum opacity to reduce flicker


### PR DESCRIPTION
## Summary
- place score, balls left and lost balls above the game canvas
- add a starfield canvas behind the game play area
- darken the game canvas background

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688566b9c86c832fb28c5e7bea1719a2