### PR TITLE
Add galaxy background effect

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2270,8 +2270,23 @@
             }
         }
 
+        let galaxies = [];
+
+        function initGalaxies() {
+            galaxies = [];
+            const galaxyCount = 3;
+            for (let i = 0; i < galaxyCount; i++) {
+                galaxies.push({
+                    x: Math.random() * starCanvas.width,
+                    y: Math.random() * starCanvas.height,
+                    radius: Math.random() * 40 + 20,
+                    angle: Math.random() * Math.PI * 2,
+                    speed: 0.001 + Math.random() * 0.003
+                });
+            }
+        }
+
         function drawStars() {
-            starCtx.clearRect(0, 0, starCanvas.width, starCanvas.height);
             starCtx.fillStyle = '#ffffff';
             stars.forEach(star => {
                 star.x += star.vx;
@@ -2286,7 +2301,30 @@
             });
         }
 
+        function drawGalaxies() {
+            starCtx.strokeStyle = 'rgba(255,255,255,0.3)';
+            starCtx.lineWidth = 0.5;
+            galaxies.forEach(galaxy => {
+                galaxy.angle += galaxy.speed;
+                const maxAngle = Math.PI * 4;
+                starCtx.beginPath();
+                for (let a = 0; a <= maxAngle; a += 0.1) {
+                    const r = galaxy.radius * (a / maxAngle);
+                    const x = galaxy.x + r * Math.cos(a + galaxy.angle);
+                    const y = galaxy.y + r * Math.sin(a + galaxy.angle);
+                    if (a === 0) {
+                        starCtx.moveTo(x, y);
+                    } else {
+                        starCtx.lineTo(x, y);
+                    }
+                }
+                starCtx.stroke();
+            });
+        }
+
         function starLoop() {
+            starCtx.clearRect(0, 0, starCanvas.width, starCanvas.height);
+            drawGalaxies();
             drawStars();
             requestAnimationFrame(starLoop);
         }
@@ -2330,6 +2368,7 @@
                 starCanvas.style.width = `${width}px`;
                 starCanvas.style.height = `${height}px`;
                 initStars();
+                initGalaxies();
                 console.log('Canvas resized:', width, height, 'Mobile:', isMobile);
             } catch (error) {
                 console.error('Resize canvas error:', error);
@@ -2337,6 +2376,7 @@
         }
         resizeCanvas();
         initStars();
+        initGalaxies();
         starLoop();
         window.addEventListener('resize', resizeCanvas);
 


### PR DESCRIPTION
## Summary
- enhance star canvas with swirling galaxy shapes
- initialize galaxies on resize
- ensure both stars and galaxies animate beneath the main game canvas

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68856eb1396c832fa1d5fd9d75494dd6