### PR TITLE
Add galaxy overlay around gameplay

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -486,6 +486,16 @@
             pointer-events: none;
         }
 
+        #starCanvasTop {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            z-index: 999;
+            pointer-events: none;
+        }
+
         #scoreBoard {
             position: absolute;
             top: 70px;
@@ -1038,6 +1048,7 @@
     </div>
     <canvas id="starCanvas"></canvas>
     <canvas id="gameCanvas"></canvas>
+    <canvas id="starCanvasTop"></canvas>
     
     <!-- Control Icons -->
     <div id="controlIcons">
@@ -1176,7 +1187,10 @@
 
 
         const starCanvas = document.getElementById('starCanvas');
+        const starCanvasTop = document.getElementById('starCanvasTop');
         const starCtx = starCanvas.getContext('2d');
+        const starCtxTop = starCanvasTop.getContext('2d');
+        const starContexts = [starCtx, starCtxTop];
         const canvas = document.getElementById('gameCanvas');
         const ctx = canvas ? canvas.getContext('2d') : null;
         if (!canvas || !ctx) {
@@ -1194,10 +1208,10 @@
         const leaderboardList = document.getElementById('leaderboardList');
         const startButton = document.getElementById('startButton');
 
-        // Verify single canvas element
-        const canvases = document.querySelectorAll('#gameCanvas, #starCanvas');
-        if (canvases.length < 2) {
-            console.warn('Expected two canvas elements for starfield and game');
+        // Verify canvas elements
+        const canvases = document.querySelectorAll('#gameCanvas, #starCanvas, #starCanvasTop');
+        if (canvases.length < 3) {
+            console.warn('Expected three canvas elements for starfield and game');
         }
 
         const gameOverScreen = document.getElementById('gameOverScreen');
@@ -2270,9 +2284,26 @@
             }
         }
 
+        let galaxies = [];
+
+        function initGalaxies() {
+            galaxies = [];
+            const galaxyCount = 3;
+            for (let i = 0; i < galaxyCount; i++) {
+                galaxies.push({
+                    x: Math.random() * starCanvas.width,
+                    y: Math.random() * starCanvas.height,
+                    radius: Math.random() * 40 + 20,
+                    angle: Math.random() * Math.PI * 2,
+                    speed: 0.001 + Math.random() * 0.003
+                });
+            }
+        }
+
         function drawStars() {
-            starCtx.clearRect(0, 0, starCanvas.width, starCanvas.height);
-            starCtx.fillStyle = '#ffffff';
+            starContexts.forEach(ctx => {
+                ctx.fillStyle = '#ffffff';
+            });
             stars.forEach(star => {
                 star.x += star.vx;
                 star.y += star.vy;
@@ -2280,13 +2311,42 @@
                 if (star.x > starCanvas.width) star.x = 0;
                 if (star.y < 0) star.y = starCanvas.height;
                 if (star.y > starCanvas.height) star.y = 0;
-                starCtx.beginPath();
-                starCtx.arc(star.x, star.y, star.size, 0, Math.PI * 2);
-                starCtx.fill();
+                starContexts.forEach(ctx => {
+                    ctx.beginPath();
+                    ctx.arc(star.x, star.y, star.size, 0, Math.PI * 2);
+                    ctx.fill();
+                });
+            });
+        }
+
+        function drawGalaxies() {
+            starContexts.forEach(ctx => {
+                ctx.strokeStyle = 'rgba(255,255,255,0.3)';
+                ctx.lineWidth = 0.5;
+            });
+            galaxies.forEach(galaxy => {
+                galaxy.angle += galaxy.speed;
+                const maxAngle = Math.PI * 4;
+                starContexts.forEach(ctx => ctx.beginPath());
+                for (let a = 0; a <= maxAngle; a += 0.1) {
+                    const r = galaxy.radius * (a / maxAngle);
+                    const x = galaxy.x + r * Math.cos(a + galaxy.angle);
+                    const y = galaxy.y + r * Math.sin(a + galaxy.angle);
+                    starContexts.forEach((ctx, index) => {
+                        if (a === 0) {
+                            ctx.moveTo(x, y);
+                        } else {
+                            ctx.lineTo(x, y);
+                        }
+                    });
+                }
+                starContexts.forEach(ctx => ctx.stroke());
             });
         }
 
         function starLoop() {
+            starContexts.forEach(ctx => ctx.clearRect(0, 0, starCanvas.width, starCanvas.height));
+            drawGalaxies();
             drawStars();
             requestAnimationFrame(starLoop);
         }
@@ -2329,7 +2389,12 @@
                 starCanvas.height = height;
                 starCanvas.style.width = `${width}px`;
                 starCanvas.style.height = `${height}px`;
+                starCanvasTop.width = width;
+                starCanvasTop.height = height;
+                starCanvasTop.style.width = `${width}px`;
+                starCanvasTop.style.height = `${height}px`;
                 initStars();
+                initGalaxies();
                 console.log('Canvas resized:', width, height, 'Mobile:', isMobile);
             } catch (error) {
                 console.error('Resize canvas error:', error);
@@ -2337,6 +2402,7 @@
         }
         resizeCanvas();
         initStars();
+        initGalaxies();
         starLoop();
         window.addEventListener('resize', resizeCanvas);
 


### PR DESCRIPTION
## Summary
- add new `starCanvasTop` overlay
- render stars and galaxies to both bottom and top layers
- resize and verify all three canvases on setup

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68856eb1396c832fa1d5fd9d75494dd6