### PR TITLE
Fix scores popup window

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1604,7 +1604,8 @@
             // Scores Icon - Open score instructions
             if (scoresIcon) {
                 scoresIcon.addEventListener('click', () => {
-                    window.open('scores.html', '_blank');
+                    const features = 'width=400,height=320,resizable=yes,scrollbars=yes';
+                    window.open('scores.html', 'scoresPopup', features);
                 });
             }
         }


### PR DESCRIPTION
## Summary
- update JS to open `scores.html` in a small popup window instead of a new tab

## Testing
- `npm test` *(fails: missing script)*
- `npm run lint` *(fails: missing script)*
- `node --check server.js`

------
https://chatgpt.com/codex/tasks/task_e_68869e0433c0832fb5c07faaf5a223d5