### PR TITLE
Switch score info to modal

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -985,6 +985,40 @@
                 font-size: 18px;
             }
         }
+        /* Score instructions modal */
+        #scoreModal {
+            display: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.8);
+            z-index: 3000;
+            align-items: center;
+            justify-content: center;
+            padding: 10px;
+        }
+        #scoreModal .modal-content {
+            position: relative;
+            background: #000;
+            color: #fff;
+            font-family: 'Orbitron', sans-serif;
+            padding: 20px;
+            border-radius: 10px;
+            max-width: 500px;
+            width: 100%;
+            max-height: 80%;
+            overflow-y: auto;
+        }
+        #scoreModal .close-btn {
+            position: absolute;
+            top: 10px;
+            right: 20px;
+            font-size: 24px;
+            color: #fff;
+            cursor: pointer;
+        }
     </style>
 </head>
 <body>
@@ -1065,6 +1099,12 @@
         <h2>Global Champions & Losers</h2>
         <ul id="globalHighScoreList"></ul>
         <button id="restartButton">Restart</button>
+    </div>
+    <div id="scoreModal">
+        <div class="modal-content">
+            <span class="close-btn" id="closeScoreModal">&times;</span>
+            <div id="scoreModalContent"></div>
+        </div>
     </div>
     <script>
         console.log('Script started - Version 2.0');
@@ -1284,6 +1324,10 @@
         const musicIcon = document.getElementById('musicIcon');
         const pauseIcon = document.getElementById('pauseIcon');
         const scoresIcon = document.getElementById('scoresIcon');
+        const scoreModal = document.getElementById('scoreModal');
+        const scoreModalContent = document.getElementById('scoreModalContent');
+        const closeScoreModal = document.getElementById('closeScoreModal');
+        let scoreModalLoaded = false;
         
         // Auto-fire system variables
         let lastFireTime = 0;
@@ -1603,8 +1647,36 @@
             // Scores Icon - Open score instructions
             if (scoresIcon) {
                 scoresIcon.addEventListener('click', () => {
-                    const features = 'width=360,height=480,resizable=yes,scrollbars=yes';
-                    window.open('scores.html', 'scoresPopup', features);
+                    if (!scoreModalLoaded) {
+                        fetch('scores.html')
+                            .then(res => res.text())
+                            .then(html => {
+                                const tmp = document.createElement('div');
+                                tmp.innerHTML = html;
+                                const container = tmp.querySelector('#container');
+                                if (scoreModalContent) {
+                                    scoreModalContent.innerHTML = container ? container.innerHTML : html;
+                                }
+                                scoreModalLoaded = true;
+                            });
+                    }
+                    if (scoreModal) {
+                        scoreModal.style.display = 'flex';
+                    }
+                });
+            }
+            if (closeScoreModal) {
+                closeScoreModal.addEventListener('click', () => {
+                    if (scoreModal) {
+                        scoreModal.style.display = 'none';
+                    }
+                });
+            }
+            if (scoreModal) {
+                scoreModal.addEventListener('click', (e) => {
+                    if (e.target === scoreModal) {
+                        scoreModal.style.display = 'none';
+                    }
                 });
             }
         }


### PR DESCRIPTION
## Summary
- use a modal popup for the scoring instructions
- inject the content from `scores.html` into the modal on demand
- close modal on background or X click

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688801d935d8832f95829ba462ca50a8